### PR TITLE
Add travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: node_js
+node_js:
+  - "8"
+
+install:
+ - npm install
+
+script: npm run test

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 # Custom recipes
 
+[![Build Status](https://img.shields.io/travis/gw2efficiency/custom-recipes.svg?style=flat-square)](https://travis-ci.org/gw2efficiency/custom-recipes)
+
 > Additional recipes which the official API does not provide.
+
+## License
+
+[GPL-3.0](LICENSE)


### PR DESCRIPTION
This PR adds a travis config that runs `npm run test` (`node src/validate.js`) and adds the build status to the readme.