### PR TITLE
Use https to access api.gw2efficiency.com

### DIFF
--- a/updater-interface/src/App.js
+++ b/updater-interface/src/App.js
@@ -25,7 +25,7 @@ class App extends Component {
     } catch (_) {
     }
 
-    const response = await window.fetch('http://api.gw2efficiency.com/items?ids=all')
+    const response = await window.fetch('https://api.gw2efficiency.com/items?ids=all')
     const items = await response.json()
 
     let map = {}


### PR DESCRIPTION
Change protocol for loading items in the frontend from http to https. This skips the redirect.