### PR TITLE
Update some food salvage recipes

### DIFF
--- a/recipes.json
+++ b/recipes.json
@@ -3114,7 +3114,6 @@
   {"name":"Exotic Extract of Nourishment","output_item_id":91726,"output_item_count":1,"ingredients":[{"count":1,"item_id":82030}],"disciplines":["Salvage"]},
   {"name":"Exotic Extract of Nourishment","output_item_id":91726,"output_item_count":1,"ingredients":[{"count":1,"item_id":12466}],"disciplines":["Salvage"]},
   {"name":"Exotic Extract of Nourishment","output_item_id":91726,"output_item_count":1,"ingredients":[{"count":1,"item_id":12452}],"disciplines":["Salvage"]},
-  {"name":"Exotic Extract of Nourishment","output_item_id":91726,"output_item_count":1,"ingredients":[{"count":1,"item_id":92138}],"disciplines":["Salvage"]},
   {"name":"Rare Extract of Nourishment","output_item_id":91684,"output_item_count":1,"ingredients":[{"count":1,"item_id":12421}],"disciplines":["Salvage"]},
   {"name":"Rare Extract of Nourishment","output_item_id":91684,"output_item_count":1,"ingredients":[{"count":1,"item_id":12437}],"disciplines":["Salvage"]},
   {"name":"Rare Extract of Nourishment","output_item_id":91684,"output_item_count":1,"ingredients":[{"count":1,"item_id":36081}],"disciplines":["Salvage"]},
@@ -3189,5 +3188,8 @@
   {"name":"Fine Extract of Nourishment","output_item_id":91838,"output_item_count":1,"ingredients":[{"count":1,"item_id":12730}],"disciplines":["Salvage"]},
   {"name":"Fine Extract of Nourishment","output_item_id":91838,"output_item_count":1,"ingredients":[{"count":1,"item_id":12190}],"disciplines":["Salvage"]},
   {"name":"Fine Extract of Nourishment","output_item_id":91838,"output_item_count":1,"ingredients":[{"count":1,"item_id":12146}],"disciplines":["Salvage"]},
-  {"name":"Fine Extract of Nourishment","output_item_id":91838,"output_item_count":1,"ingredients":[{"count":1,"item_id":12204}],"disciplines":["Salvage"]}
+  {"name":"Fine Extract of Nourishment","output_item_id":91838,"output_item_count":1,"ingredients":[{"count":1,"item_id":12204}],"disciplines":["Salvage"]},
+  {"name":"Exotic Extract of Nourishment","output_item_id":91726,"output_item_count":1,"ingredients":[{"count":1,"item_id":82541}],"disciplines":["Salvage"]},
+  {"name":"Exotic Extract of Nourishment","output_item_id":91726,"output_item_count":1,"ingredients":[{"count":1,"item_id":82642}],"disciplines":["Salvage"]},
+  {"name":"Exotic Extract of Nourishment","output_item_id":91726,"output_item_count":10,"ingredients":[{"count":1,"item_id":83545}],"disciplines":["Salvage"]}
 ]


### PR DESCRIPTION
`+ 83545: Pitcher of Desert-Spiced Coffee`
This is a feast, but it drops from reward tracks and an event, so it's like halloween food in that it should never require obtaining the recipe. (Currently optimal right now)

`+ 82541: Bowl of "Elon Red"`
`+ 82642: Cup of Light-Roasted Coffee`
These require a recipe for 5 trade contracts and the completion of a PoF heart, similar to the currently implemented 81799: Oysters with Zesty Sauce and 81615: Oysters with Cocktail Sauce. (I think you could make the argument for removing them all instead of adding them all, too.)

`- 92138: Saint Bones (unsalvagable)`
These cannot be salvaged despite being craftable ¯\\\_(ツ)\_/¯ 

I didn't add things like Feast of Ghost Pepper Poppers/Feast of Rare Veggie Pizzas that could semi-plausibly become optimal and have a method of being obtained that isn't crafting - doesn't seem worth the minor headache if the calc ever suggests you craft them.
