### PR TITLE
Updater interface: Extract api hostname

### DIFF
--- a/updater-interface/.env
+++ b/updater-interface/.env
@@ -1,0 +1,2 @@
+REACT_APP_API_HOST = minirack.io
+# REACT_APP_API_HOST = localhost

--- a/updater-interface/src/App.js
+++ b/updater-interface/src/App.js
@@ -4,6 +4,8 @@ import {observer} from 'mobx-react'
 import c from 'classnames'
 import pick from 'lodash.pick'
 
+const apiHostname = process.env.REACT_APP_API_HOST
+
 @observer
 class App extends Component {
   @observable apiResponse = null
@@ -38,7 +40,7 @@ class App extends Component {
   }
 
   async fetchFromAPI () {
-    const response = await window.fetch(`http://minirack.io:3001/api/${this.index}`)
+    const response = await window.fetch(`http://${apiHostname}:3001/api/${this.index}`)
     this.apiResponse = await response.json()
   }
 
@@ -55,7 +57,7 @@ class App extends Component {
   async dismiss () {
     const body = {action: 'dismiss'}
 
-    await window.fetch(`http://minirack.io:3001/api/${this.index}`, {
+    await window.fetch(`http://${apiHostname}:3001/api/${this.index}`, {
       method: 'POST',
       body: JSON.stringify(body),
       headers: {
@@ -69,7 +71,7 @@ class App extends Component {
   async add () {
     const body = {action: 'add'}
 
-    await window.fetch(`http://minirack.io:3001/api/${this.index}`, {
+    await window.fetch(`http://${apiHostname}:3001/api/${this.index}`, {
       method: 'POST',
       body: JSON.stringify(body),
       headers: {
@@ -83,7 +85,7 @@ class App extends Component {
   async overwrite (existingIndex) {
     const body = {action: 'overwrite', existingIndex}
 
-    await window.fetch(`http://minirack.io:3001/api/${this.index}`, {
+    await window.fetch(`http://${apiHostname}:3001/api/${this.index}`, {
       method: 'POST',
       body: JSON.stringify(body),
       headers: {


### PR DESCRIPTION
In order to be able to open and try the interactive updater interface react app included here, I had to set the API hostname to localhost. This extracts the hostname (and puts it in a `.env` file and commits it, somewhat arbitrarily; one could also gitignore `.env`, commit `.env.example`, and instruct users to copy their own... or load it in the script/a package script, or do any number of other things. Wasn't sure if this was really intended for external use, but hey.)